### PR TITLE
fix: remove VERSION from upgrade auxiliary file downloads

### DIFF
--- a/internal/version/upgrade.go
+++ b/internal/version/upgrade.go
@@ -62,7 +62,7 @@ func UpgradeToLatest(currentVersion, latestVersion string, info, warn func(strin
 	}
 
 	// Download auxiliary files from the release tag (not main branch)
-	for _, file := range []string{"README.md", "VERSION", "LICENSE"} {
+	for _, file := range []string{"README.md", "LICENSE"} {
 		url := fmt.Sprintf("https://raw.githubusercontent.com/lucasmodrich/git-worktree-manager/refs/tags/v%s/%s", latestVersion, file)
 		dest := filepath.Join(installDir, file)
 		if err := downloadFile(url, dest); err != nil {


### PR DESCRIPTION
## Summary

- Remove `"VERSION"` from the auxiliary files list in `UpgradeToLatest` (`internal/version/upgrade.go`)

## Root Cause

The upgrade command tries to download `README.md`, `VERSION`, and `LICENSE` from the tagged release. The repo has no `VERSION` file, producing a warning on every upgrade:

```
⚠️ Warning: failed to download VERSION: HTTP 404: https://raw.githubusercontent.com/lucasmodrich/git-worktree-manager/refs/tags/v2.2.3/VERSION
```

The version is already embedded in the binary via `-ldflags -X main.version={{.Version}}`, so a separate `VERSION` file is redundant.

## Test plan

- [ ] `go test ./...` passes (verified locally ✓)
- [ ] `gwtm upgrade` completes without any warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)